### PR TITLE
Fix Sublime Text 3 build

### DIFF
--- a/jsbeautify.py
+++ b/jsbeautify.py
@@ -69,7 +69,6 @@ def is_js_buffer(view):
   region = sublime.Region(0, view.size())
   code = view.substr(region)
   header="#!/usr/bin/env node"
-  print "hello"
   if header in code.split('\n')[0]:
     return True
   if (fName != None): # file exists, pull syntax type from extension


### PR DESCRIPTION
`print "hello"` is invalid Python 3 syntax and causes the plugin to not work - deleting line.