### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Thanks.
 
 # JS Beautify Wrapper for Sublime Text
 
-##Installation
+## Installation
 
 1.Just 'Javascript Beautify' from Sublime's package manager.
 
 
-##Comment
+## Comment
 1.current support embed js within jade file
 
 

--- a/libs/js-beautify/CONTRIBUTING.md
+++ b/libs/js-beautify/CONTRIBUTING.md
@@ -59,10 +59,10 @@ Each platform has it's own release process.
 
 NOTE: Before you do any of these make sure the latest changes have passed the travis-ci build!
 
-##Web
+## Web
 Merge changes from `master` to `gh-pages` branch.  This is very low cost and can be done whenever is convenient.
 
-##Python
+## Python
 NOTE: For now, we'd like to keep python and node version numbers synchronized,
 so if you publish a python release, you should publish a node release as well.
 
@@ -84,7 +84,7 @@ python setup.py sdist bdist_wininst upload
 git push
 ```
 
-##Node
+## Node
 NOTE: For now, we'd like to keep python and node version numbers synchronized,
 so if you plan to publish a node release, you should publish a python release *first*,
 then perform the steps below.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
